### PR TITLE
fix: artifacts names in human readable way support added

### DIFF
--- a/cmd/newContent.go
+++ b/cmd/newContent.go
@@ -123,8 +123,8 @@ func getContentName(fs afero.Fs, inputs []string, c *config.SveltinConfig) (conf
 	switch numOfArgs := len(inputs); {
 	case numOfArgs < 1:
 		contentNamePromptContent := config.PromptContent{
-			ErrorMsg: "Please, provide a name for the content.",
-			Label:    "What's the content name? (it will be the slug to the page)",
+			ErrorMsg: "Please, provide a title for the content.",
+			Label:    "What's the content title? (it will be the slug to the page)",
 		}
 		contentName := common.PromptGetInput(contentNamePromptContent)
 		contentType, err := promptContentTemplateSelection(templateFlag)
@@ -134,7 +134,7 @@ func getContentName(fs afero.Fs, inputs []string, c *config.SveltinConfig) (conf
 		utils.ExitIfError(err)
 
 		return config.TemplateData{
-			Name:     utils.ToValidName(contentName),
+			Name:     utils.ToSlug(contentName),
 			Type:     contentType,
 			Resource: contentResource,
 		}, nil
@@ -150,7 +150,7 @@ func getContentName(fs afero.Fs, inputs []string, c *config.SveltinConfig) (conf
 		utils.ExitIfError(err)
 
 		return config.TemplateData{
-			Name:     utils.ToValidName(contentName),
+			Name:     utils.ToSlug(contentName),
 			Type:     contentType,
 			Resource: contentResource,
 		}, nil

--- a/cmd/newMetadata.go
+++ b/cmd/newMetadata.go
@@ -204,10 +204,10 @@ func promptMetadataName(inputs []string) (string, error) {
 			Label:    "What's the metadata name?",
 		}
 		name = common.PromptGetInput(metadataNamePromptContent)
-		return name, nil
+		return utils.ToSlug(name), nil
 	case numOfArgs == 1:
 		name = inputs[0]
-		return name, nil
+		return utils.ToSlug(name), nil
 	default:
 		err := errors.New("something went wrong: name not valid")
 		return "", sveltinerr.NewDefaultError(err)

--- a/cmd/newPage.go
+++ b/cmd/newPage.go
@@ -102,10 +102,10 @@ func getPageName(inputs []string) (string, error) {
 			Label:    "What's the page name?",
 		}
 		name = common.PromptGetInput(pageNamePromptContent)
-		return utils.ToValidName(name), nil
+		return utils.ToSlug(name), nil
 	case numOfArgs == 1:
 		name = inputs[0]
-		return utils.ToValidName(name), nil
+		return utils.ToSlug(name), nil
 	default:
 		err := errors.New("something went wrong: value not valid")
 		return "", sveltinerr.NewDefaultError(err)

--- a/cmd/newResource.go
+++ b/cmd/newResource.go
@@ -91,7 +91,7 @@ func RunNewResourceCmd(cmd *cobra.Command, args []string) {
 	// NEW FILE: src/lib/<resource_name>/get<resource_name>.js
 	listLogger.Append(logger.LevelInfo, "Creating the lib file for the resource")
 	libFile := &composer.File{
-		Name:       utils.ToLibFilename(resourceName),
+		Name:       utils.ToLibFile(resourceName),
 		TemplateId: LIB,
 		TemplateData: &config.TemplateData{
 			Name:   resourceName,
@@ -160,10 +160,10 @@ func promptResourceName(inputs []string) (string, error) {
 			Label:    "What's the resource name? (e.g. posts, portfolio ...)",
 		}
 		name = common.PromptGetInput(resourceNamePromptContent)
-		return name, nil
+		return utils.ToSlug(name), nil
 	case numOfArgs == 1:
 		name = inputs[0]
-		return name, nil
+		return utils.ToSlug(name), nil
 	default:
 		err := errors.New("something went wrong: value not valid")
 		return "", sveltinerr.NewDefaultError(err)

--- a/resources/internal/templates/page/page.svelte.gotxt
+++ b/resources/internal/templates/page/page.svelte.gotxt
@@ -1,10 +1,12 @@
+{{ $pageName := .Name | ToVariableName}}
 <script lang="ts">
 	import { website } from '$config/website.js';
-	import { IWebPageMetadata, OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
+	import type { IWebPageMetadata } from '@sveltinio/seo/types';
+	import { OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
 	import { PageMetaTags, JsonLdWebPage, JsonLdBreadcrumbs } from '@sveltinio/seo';
 	import { getFavicon, getPageUrl } from '$lib/utils/strings.js';
 
-	const {{ .Name | ToPageVariableName }}Page: IWebPageMetadata = {
+	const {{ $pageName }}Page: IWebPageMetadata = {
 		url: getPageUrl('{{ .Name }}', website),
 		title: '{{ .Name | ToTitle }}',
 		description: website.seoDescription,
@@ -19,9 +21,9 @@
 	};
 </script>
 
-<PageMetaTags data={ {{ .Name | ToPageVariableName }}Page } />
-<JsonLdWebPage data={ {{ .Name | ToPageVariableName }}Page } />
-<JsonLdBreadcrumbs baseURL={website.baseURL} parent="" currentTitle={ {{ .Name | ToPageVariableName }}Page.title} />
+<PageMetaTags data={ {{ $pageName }}Page } />
+<JsonLdWebPage data={ {{ $pageName }}Page } />
+<JsonLdBreadcrumbs baseURL={website.baseURL} parent="" currentTitle={ {{ $pageName }}Page.title} />
 
 <!-- Page markup-->
 <section class="page">

--- a/resources/internal/templates/page/page.svx.gotxt
+++ b/resources/internal/templates/page/page.svx.gotxt
@@ -2,13 +2,15 @@
 title: {{ .Name | ToTitle }}
 ---
 
+{{ $pageName := .Name | ToVariableName }}
 <script lang="ts">
 	import { website } from '$config/website.js';
-	import { IWebPageMetadata, OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
+	import type { IWebPageMetadata } from '@sveltinio/seo/types';
+	import { OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
 	import { PageMetaTags, JsonLdWebPage, JsonLdBreadcrumbs } from '@sveltinio/seo';
 	import { getFavicon, getPageUrl } from '$lib/utils/strings.js';
 
-	const {{ .Name | ToPageVariableName}}Page: IWebPageMetadata = {
+	const {{ $pageName }}Page: IWebPageMetadata = {
 		url: getPageUrl('{{ .Name }}', website),
 		title: title,
 		description: website.seoDescription,
@@ -23,9 +25,9 @@ title: {{ .Name | ToTitle }}
 	};
 </script>
 
-<PageMetaTags data={ {{ .Name | ToPageVariableName }}Page } />
-<JsonLdWebPage data={ {{ .Name | ToPageVariableName }}Page } />
-<JsonLdBreadcrumbs baseURL={website.baseURL} parent="" currentTitle={ {{ .Name | ToPageVariableName }}Page.title} />
+<PageMetaTags data={ {{ $pageName }}Page } />
+<JsonLdWebPage data={ {{ $pageName }}Page } />
+<JsonLdBreadcrumbs baseURL={website.baseURL} parent="" currentTitle={ {{ $pageName }}Page.title} />
 
 <!-- Page markup-->
 <section class="page">

--- a/resources/internal/templates/resource/api.gotxt
+++ b/resources/internal/templates/resource/api.gotxt
@@ -1,10 +1,9 @@
-import {{ .Name }} from '$lib/{{ .Name }}/get{{ .Name | Capitalize }}.js';
-import type { EndpointOutput } from '@sveltejs/kit';
+import { published } from '$lib/{{ .Name }}/{{ .Name | ToLibFile }}';
 
-export async function get(): Promise<EndpointOutput> {
-   const body = Object.keys({{ .Name }}).map((slug) => ({
+export async function get() {
+   const body = Object.keys(published).map((slug) => ({
       slug,
-      ...{{ .Name }}[slug]
+      ...published[slug]
    }));
    return {
       status: 200,

--- a/resources/internal/templates/resource/index.gotxt
+++ b/resources/internal/templates/resource/index.gotxt
@@ -34,7 +34,7 @@
 		};
 	}
 </script>
-
+{{ $varName := .Name | ToVariableName}}
 <script lang="ts">
 	import { website } from '$config/website.js';
 	import { Card } from '@sveltinio/widgets';
@@ -42,14 +42,14 @@
 	import type { IWebPageMetadata } from '@sveltinio/seo/types';
 	import { OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
 	import { PageMetaTags, JsonLdWebPage, JsonLdBreadcrumbs } from '@sveltinio/seo';
-	import { getFavicon, getPageUrl } from '$lib/utils/strings.js';
+	import { ToTitle, getFavicon, getPageUrl } from '$lib/utils/strings.js';
 
 	export let resourceName: string;
 	export let itemsList: Array<ResourceContent>;
 
 	const sortedItemsList = orderBy(itemsList, (item) => item.metadata.created_at, ['desc']);
 
-	const {{ .Name }}IndexPage: IWebPageMetadata = {
+	const {{ $varName }}IndexPage: IWebPageMetadata = {
 		url: getPageUrl(resourceName, website),
 		title: website.name,
 		description: 'Here you can find the list of all available {{ .Name }}.',
@@ -64,14 +64,14 @@
 	};
 </script>
 
-<PageMetaTags data={ {{ .Name }}IndexPage } />
-<JsonLdWebPage data={ {{ .Name }}IndexPage } />
-<JsonLdBreadcrumbs baseURL={website.baseURL} parent={resourceName} currentTitle={ {{ .Name }}IndexPage.title} />
+<PageMetaTags data={ {{ $varName }}IndexPage } />
+<JsonLdWebPage data={ {{ $varName }}IndexPage } />
+<JsonLdBreadcrumbs baseURL={website.baseURL} parent={resourceName} currentTitle={ {{ $varName }}IndexPage.title} />
 
 <section class="artifact-container">
 	<div class="content">
 		{#if sortedItemsList.length != 0 }
-		<h1>All {resourceName}</h1>
+		<h1>{ToTitle(resourceName)}</h1>
 		<div class="cards">
 		{#each sortedItemsList as item }
 			<Card {item} />
@@ -80,7 +80,7 @@
 		{:else}
 		<h2 class="message warning">
 			Nothing to show here! Create some content first and reload the page:
-			<span><pre><code class="text-default">sveltin new content {{ .Name }}/getting-started</code></pre></span>
+			<span><pre><code class="text-default">sveltin new content {{ $varName }}/getting-started</code></pre></span>
 		</h2>
 		{/if}
 	</div>

--- a/resources/internal/templates/resource/lib.gotxt
+++ b/resources/internal/templates/resource/lib.gotxt
@@ -1,12 +1,12 @@
 import filter from 'lodash-es/filter.js';
-
-const {{ .Name }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Name }}/**/*.{md,svx}');
-const {{ .Name }}List = Object.entries({{ .Name }})
+{{ $varName := .Name | ToVariableName}}
+const {{ $varName }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Name }}/**/*.{md,svx}');
+const {{ $varName }}List = Object.entries({{ $varName }})
    .map(([_, item]) => ({
       ...item.metadata,
       ...item.default.render()
    }))
    .sort((a, b) => (a.date < b.date ? 1 : -1));
 
-const published = filter({{ .Name }}List, ['draft', false]);
-export default published;
+const published = filter({{ $varName }}List, ['draft', false]);
+export { published };

--- a/resources/internal/templates/resource/metadata/apiList.gotxt
+++ b/resources/internal/templates/resource/metadata/apiList.gotxt
@@ -1,10 +1,9 @@
-import {{ .Name }} from '$lib/{{ .Resource }}/get{{ .Name | Capitalize }}.js';
+import { groupedBy } from '$lib/{{ .Resource }}/{{ .Name | ToLibFile }}';
 import first from 'lodash-es/first.js';
-import type { EndpointOutput } from '@sveltejs/kit';
 
-export async function get(): Promise<EndpointOutput> {
+export async function get() {
    return {
       status: 200,
-      body: JSON.stringify(first({{ .Name }}))
+      body: JSON.stringify(first(groupedBy))
    };
 }

--- a/resources/internal/templates/resource/metadata/apiSingle.gotxt
+++ b/resources/internal/templates/resource/metadata/apiSingle.gotxt
@@ -1,9 +1,8 @@
-import {{ .Name }} from '$lib/{{ .Resource }}/get{{ .Name | Capitalize }}.js';
-import type { EndpointOutput } from '@sveltejs/kit';
+import { groupedBy } from '$lib/{{ .Resource }}/{{ .Name | ToLibFile }}';
 
-export async function get(): Promise<EndpointOutput> {
+export async function get() {
    return {
       status: 200,
-      body: JSON.stringify({{ .Name }})
+      body: JSON.stringify(groupedBy)
    };
 }

--- a/resources/internal/templates/resource/metadata/index.gotxt
+++ b/resources/internal/templates/resource/metadata/index.gotxt
@@ -1,15 +1,15 @@
 <script lang="ts" context="module">
 	import type { Load } from '@sveltejs/kit';
-
+	{{ $varName := .Name | ToVariableName}}
 	export const load: Load = async ({ fetch }) => {
 		const _url = '/api/{{ .Config.GetAPIVersion }}/{{ .Resource }}/{{ .Name }}/{{ .Config.GetPublicMetadataAPIFilename }}'
 		const res = await fetch(_url);
 		if (res.ok) {
 			const data = await res.json();
-			const {{ .Name }} = data as unknown as Array<Metadata>;
+			const {{ $varName }} = data as unknown as Array<Metadata>;
 
 			return {
-				props: { {{ .Name }} }
+				props: { {{ $varName }} }
 			};
 		}
 		return {
@@ -23,14 +23,14 @@
 	import { base } from '$app/paths';
 	import type { Metadata } from '$lib/interfaces';
 
-	export let {{ .Name }}: Array<Metadata>;
+	export let {{ $varName }}: Array<Metadata>;
 </script>
 
 <div class="artifact-container">
 	<div class="content">
 		<h1>Grouped by {{ .Name | Capitalize }}</h1>
-		{#if {{ .Name }}.length != 0}
-			{#each {{ .Name }} as metadata}
+		{#if {{ $varName }}.length != 0}
+			{#each {{ $varName}} as metadata}
 			<h2>
 				<a sveltekit:prefetch href="{base}/{{.Resource}}/{{ .Name }}/{metadata.name}">{metadata.name}</a>
 			</h2>
@@ -42,7 +42,7 @@
 			{/each}
 		{:else}
 			<h2 class="message warning">
-			Please, check all your content ensuring the YAML frontmatter contains "<i>{{ .Name }}</i>".
+			Please, check all your content ensuring the YAML frontmatter contains "<i>{{ .Name | ToVariableName}}</i>".
 			</h2>
 		{/if}
 	</div>

--- a/resources/internal/templates/resource/metadata/libList.gotxt
+++ b/resources/internal/templates/resource/metadata/libList.gotxt
@@ -1,12 +1,13 @@
 import { groupedByMany } from '$lib/utils/collections.js';
 import filter from 'lodash-es/filter.js';
-
-const {{ .Resource }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Resource }}/**/*.{md,svx}');
-const {{ .Resource }}List = Object.entries({{ .Resource }})
+{{ $resourceName := .Resource | ToVariableName}}
+const {{ $resourceName }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Resource }}/**/*.{md,svx}');
+const {{ $resourceName }}List = Object.entries({{ .$resourceName }})
    .map(([, item]) => item.metadata)
    .sort((a, b) => (a.date < b.date ? 1 : -1));
 
-const published = filter({{ .Resource }}List, ['draft', false])
+const published = filter({{ $resourceName }}List, ['draft', false])
 const values = ['title', 'slug', 'headline'];
 
-export default groupedByMany('{{ .Name }}', published, values);
+const groupedBy = groupedByMany('{{ .Name | ToVariableName }}', published, values);
+export { groupedBy }

--- a/resources/internal/templates/resource/metadata/libSingle.gotxt
+++ b/resources/internal/templates/resource/metadata/libSingle.gotxt
@@ -1,12 +1,13 @@
 import { groupedByOne } from '$lib/utils/collections.js';
 import filter from 'lodash-es/filter.js';
-
-const {{ .Resource }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Resource }}/**/*.{md,svx}');
-const {{ .Resource }}List = Object.entries({{ .Resource }})
+{{ $resourceName := .Resource | ToVariableName}}
+const {{ $resourceName }} = import.meta.globEager('/{{ .Config.Paths.Content }}/{{ .Resource }}/**/*.{md,svx}');
+const {{ $resourceName }}List = Object.entries({{ $resourceName }})
    .map(([, item]) => item.metadata)
    .sort((a, b) => (a.date < b.date ? 1 : -1));
 
-const published = filter({{ .Resource }}List, ['draft', false])
+const published = filter({{ $resourceName }}List, ['draft', false])
 const values = ['title', 'slug', 'headline'];
 
-export default groupedByOne('{{ .Name }}', published, values);
+const groupedBy = groupedByOne('{{ .Name | ToVariableName }}', published, values);
+export { groupedBy }

--- a/sveltinlib/builder/content_builder.go
+++ b/sveltinlib/builder/content_builder.go
@@ -81,6 +81,9 @@ func (b *resContentBuilder) setFuncs() {
 		"Today": func() string {
 			return utils.Today()
 		},
+		"ToVariableName": func(txt string) string {
+			return utils.ToVariableName(txt)
+		},
 	}
 }
 

--- a/sveltinlib/builder/metadata_builder.go
+++ b/sveltinlib/builder/metadata_builder.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sveltinio/sveltin/config"
 	"github.com/sveltinio/sveltin/sveltinlib/sveltinerr"
+	"github.com/sveltinio/sveltin/utils"
 )
 
 const (
@@ -96,6 +97,12 @@ func (b *metadataContentBuilder) SetTemplateData(artifactData *config.TemplateDa
 func (b *metadataContentBuilder) setFuncs() {
 	b.Funcs = template.FuncMap{
 		"Capitalize": strings.Title,
+		"ToVariableName": func(txt string) string {
+			return utils.ToVariableName(txt)
+		},
+		"ToLibFile": func(txt string) string {
+			return utils.ToLibFile(txt)
+		},
 	}
 }
 

--- a/sveltinlib/builder/page_builder.go
+++ b/sveltinlib/builder/page_builder.go
@@ -78,8 +78,8 @@ func (b *publicPageContentBuilder) setFuncs() {
 		"ToTitle": func(text string) string {
 			return utils.ToTitle(text)
 		},
-		"ToPageVariableName": func(text string) string {
-			return utils.ToPageVariableName(text)
+		"ToVariableName": func(text string) string {
+			return utils.ToVariableName(text)
 		},
 	}
 }

--- a/sveltinlib/builder/resource_builder.go
+++ b/sveltinlib/builder/resource_builder.go
@@ -10,11 +10,11 @@ package builder
 
 import (
 	"errors"
-	"strings"
 	"text/template"
 
 	"github.com/sveltinio/sveltin/config"
 	"github.com/sveltinio/sveltin/sveltinlib/sveltinerr"
+	"github.com/sveltinio/sveltin/utils"
 )
 
 const (
@@ -83,7 +83,12 @@ func (b *resourceContentBuilder) SetTemplateData(artifactData *config.TemplateDa
 
 func (b *resourceContentBuilder) setFuncs() {
 	b.Funcs = template.FuncMap{
-		"Capitalize": strings.Title,
+		"ToVariableName": func(txt string) string {
+			return utils.ToVariableName(txt)
+		},
+		"ToLibFile": func(txt string) string {
+			return utils.ToLibFile(txt)
+		},
 	}
 }
 

--- a/sveltinlib/pathmaker/sveltin_pathmaker.go
+++ b/sveltinlib/pathmaker/sveltin_pathmaker.go
@@ -133,7 +133,7 @@ func (maker *SveltinPathMaker) GetPathToExistingResources() string {
 // GetResourceLibFilename returns a string representing the path to the resource lib file
 // for a sveltin project relative to the current working directory.
 func (maker *SveltinPathMaker) GetResourceLibFilename(artifact string) string {
-	return utils.ToLibFilename(artifact)
+	return utils.ToLibFile(artifact)
 }
 
 // GetResourceContentFilename returns a string representing the filename

--- a/utils/text.go
+++ b/utils/text.go
@@ -15,14 +15,15 @@ import (
 
 // ToMDFile returns a string with .md suffix
 // example: ToMDFile("welcome") returns 'welcome.md'.
-func ToMDFile(text string) string {
-	return strings.ToUpper(text) + ".md"
+func ToMDFile(txt string) string {
+	return strings.ToUpper(txt) + ".md"
 }
 
-// ToLibFilename returns a string a valid lib filename
+// ToLibFile returns a string a valid lib filename
 // example: ToLibFilename("category") returns 'getCategory.js'.
-func ToLibFilename(txt string) string {
-	return `get` + strings.Title(txt) + `.js`
+func ToLibFile(txt string) string {
+	vName := ToVariableName(txt)
+	return `get` + strings.Title(vName) + `.js`
 }
 
 // ToTitle replace all '-' char with a white space and
@@ -43,10 +44,14 @@ func Trimmed(txt string) string {
 	return strings.Trim(txt, "\"")
 }
 
-// ToValidName returns a copy of string replacing '_' with '-'
-// example: ToValidName("getting_started") returns 'getting-started'.
-func ToValidName(txt string) string {
-	return strings.ReplaceAll(txt, "_", "-")
+// ToSlug returns a copy of string with lowercase
+// replacing "_" and whitespaces with "-"
+// example: ToSlug("New Resource") returns new-resource.
+func ToSlug(txt string) string {
+	cleanString := strings.ToLower(txt)
+	cleanString = strings.ReplaceAll(cleanString, " ", "-")
+	cleanString = strings.ReplaceAll(cleanString, "_", "-")
+	return cleanString
 }
 
 // ToBasePath returns a copy of string replacing all occurrences
@@ -55,11 +60,10 @@ func ToBasePath(fullpath string, replace string) string {
 	return strings.ReplaceAll(fullpath, replace+"/", "")
 }
 
-// ToPageVariableName returns a human readable string
-// replacing '-' with white space and capitalizing
-// first letters of each word.
-func ToPageVariableName(txt string) string {
-	var frags = strings.Split(txt, "-")
+// ToVariableName returns a copy of string to be used as variable name.
+func ToVariableName(txt string) string {
+	slug := ToSlug(txt)
+	var frags = strings.Split(slug, "-")
 	for i := range frags {
 		if i != 0 {
 			frags[i] = strings.Title(frags[i])

--- a/utils/text_test.go
+++ b/utils/text_test.go
@@ -16,6 +16,10 @@ func TestTextUtils(t *testing.T) {
 	is.Equal("2022", CurrentYear())
 	is.Equal(2, PlusOne(1))
 	is.Equal(3, Sum(1, 2))
-	is.Equal("quick-start", ToValidName("quick_start"))
-	is.Equal("quickStartPage", ToPageVariableName("quick-start-page"))
+	is.Equal("quick-start", ToSlug("quick_start"))
+	is.Equal("resource-name", ToSlug("Resource Name"))
+	is.Equal("resource-name", ToSlug("Resource_Name"))
+	is.Equal("resource-name", ToSlug("Resource name"))
+	is.Equal("quickStartPage", ToVariableName("quick-start-page"))
+	is.Equal("resourceName", ToVariableName("Resource name"))
 }


### PR DESCRIPTION
- fix: it is now possible to use readable name when running command in interactive way
- fix: pages templates still used a wrong import for IWebPageMetadata from @sveltinio/seo
- fix: EndpointOutput import removed from api template files
- refactor: string utilities methods
