### PR TITLE
fix: postcss for tailwind based projects

### DIFF
--- a/resources/internal/templates/themes/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/package.json.gotxt
@@ -42,7 +42,7 @@
 		"postcss": "^8.4.5",
 		"postcss-import": "^14.0.2",
 		"postcss-load-config": "^3.1.1",
-		"postcss-nesting": "^10.1.2",
+		"postcss-nested": "^5.0.6",
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.6.0",
 		"prettier-plugin-tailwindcss": "^0.1.4",

--- a/resources/internal/templates/themes/tailwindcss/postcss.config.cjs
+++ b/resources/internal/templates/themes/tailwindcss/postcss.config.cjs
@@ -1,18 +1,19 @@
 const cssnano = require('cssnano');
+const autoprefixer = require('autoprefixer');
+const postcssImport = require('postcss-import');
+const nesting = require('tailwindcss/nesting');
+const tailwindcss = require('tailwindcss');
 
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 
 const config = {
 	plugins: [
-		require('postcss-import'),
-		require('tailwindcss/nesting')(require('postcss-nesting')),
-		require('tailwindcss'),
-		require('autoprefixer'),
-		!dev &&
-			cssnano({
-				preset: 'default',
-			}),
+		postcssImport,
+		nesting,
+		tailwindcss,
+		autoprefixer,
+		!dev && cssnano,
 	],
 };
 

--- a/resources/internal/templates/themes/tailwindcss/styled/app.css
+++ b/resources/internal/templates/themes/tailwindcss/styled/app.css
@@ -1,5 +1,6 @@
 @tailwind base;
 @tailwind components;
+@tailwind utilities;
 
 @layer base {
 	:root {
@@ -20,53 +21,49 @@
 	}
 }
 
-@layer components {
-	.main-container {
-		@apply relative min-h-screen w-full flex flex-col justify-center;
-	}
-
-	.btn {
-		@apply relative inline-flex items-center pl-2 pr-2 pt-2 pb-2 text-sm font-medium border-2;
-	}
-
-	.btn-accent {
-		@apply relative inline-flex items-center px-2 py-2 text-sm font-medium text-white bg-river border-2 border-river rounded-l-lg hover:bg-haiti focus:z-10 focus:outline-none focus:ring-1 focus:ring-river focus:border-white lg:px-8;
-	}
-
-	.btn-base {
-		@apply relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium border-2 border-river rounded-r-lg focus:z-10 focus:outline-none focus:ring-1 focus:ring-auburn focus:border-auburn lg:px-8;
-	}
-
-	.artifact-container {
-		@apply text-skin-dark flex flex-col justify-center;
-	}
-
-	.artifact-container > .content {
-		@apply max-w-4xl mx-auto my-7 p-10 text-gray-800 leading-6;
-	}
-
-	.artifact-container > .content h1 {
-		@apply text-left leading-8 text-2xl font-medium mx-auto break-words;
-	}
-
-	.artifact-container > .content h2 {
-		@apply text-left text-xl font-normal leading-7 my-2 mx-0;
-	}
-
-	.artifact-container > .content > .message {
-		@apply py-2 px-4 rounded-md;
-	}
-
-	.artifact-container > .content > .warning {
-		@apply bg-orange-200;
-	}
-
-	.text-default {
-		@apply text-base leading-6;
-	}
+.main-container {
+	@apply relative min-h-screen w-full flex flex-col justify-center;
 }
 
-@tailwind utilities;
+.btn {
+	@apply relative inline-flex items-center pl-2 pr-2 pt-2 pb-2 text-sm font-medium border-2;
+}
+
+.btn-accent {
+	@apply relative inline-flex items-center px-2 py-2 text-sm font-medium text-white bg-river border-2 border-river rounded-l-lg hover:bg-haiti focus:z-10 focus:outline-none focus:ring-1 focus:ring-river focus:border-white lg:px-8;
+}
+
+.btn-base {
+	@apply relative inline-flex items-center px-2 py-2 -ml-px text-sm font-medium border-2 border-river rounded-r-lg focus:z-10 focus:outline-none focus:ring-1 focus:ring-auburn focus:border-auburn lg:px-8;
+}
+
+.artifact-container {
+	@apply text-skin-dark flex flex-col justify-center;
+}
+
+.content {
+	@apply max-w-4xl mx-auto my-7 p-10 text-gray-800 leading-6;
+}
+
+.content h1 {
+	@apply text-left leading-8 text-2xl font-medium mx-auto break-words;
+}
+
+.content h2 {
+	@apply text-left text-xl font-normal leading-7 my-2 mx-0;
+}
+
+.message {
+	@apply py-2 px-4 rounded-md;
+}
+
+.warning {
+	@apply bg-orange-200;
+}
+
+.text-default {
+	@apply text-base leading-6;
+}
 
 .markdown-body {
 	@apply mx-auto p-11 prose-base;

--- a/resources/internal/templates/themes/tailwindcss/svelte.config.js
+++ b/resources/internal/templates/themes/tailwindcss/svelte.config.js
@@ -19,7 +19,7 @@ const config = {
 	preprocess: [
 		mdsvex(mdsvexConfig),
 		preprocess({
-			//postcss: true,
+			postcss: true,
 			preserve: ['ld+json'],
 		}),
 	],


### PR DESCRIPTION
This should fix [#10]

- `package.json`: `postcss-nesting` dependency replaced with `postcss-nested` (the one used by tailwind as default)
- `app.css`: moving out from the components layer classes. Those classes do not need to use tailwind modifiers then do not need to live within a `@layer`
- `svelte-preprocess`: enabling `postcss`