### PR TITLE
chore: sveltekit updated to next-301

### DIFF
--- a/resources/internal/templates/resource/metadata/slug.ts.gotxt
+++ b/resources/internal/templates/resource/metadata/slug.ts.gotxt
@@ -13,5 +13,12 @@ export async function get({ params }) {
 		};
 	}
 
-	return { fallthrough: true };
+	// return errors
+	const errors: Record<string, Error> = {};
+	return {
+		status: 404,
+		body: {
+			errors
+		}
+	};
 }

--- a/resources/internal/templates/resource/slug.ts.gotxt
+++ b/resources/internal/templates/resource/slug.ts.gotxt
@@ -18,5 +18,12 @@ export async function get({ params }) {
 		};
 	}
 
-	return { fallthrough: true };
+	// return errors
+	const errors: Record<string, Error> = {};
+	return {
+		status: 404,
+		body: {
+			errors
+		}
+	};
 }

--- a/resources/internal/templates/themes/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/bootstrap/package.json.gotxt
@@ -17,7 +17,7 @@
 		"@indaco/svelte-iconoir": "^2.2.1",
 		"@popperjs/core": "^2.10.2",
 		"@sveltejs/adapter-static": "^1.0.0-next.29",
-		"@sveltejs/kit": "1.0.0-next.295",
+		"@sveltejs/kit": "1.0.0-next.301",
 		"@sveltinio/essentials": "^0.1.2",
 		"@sveltinio/seo": "^0.1.5",
 		"@sveltinio/services": "^0.1.2",

--- a/resources/internal/templates/themes/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/bulma/package.json.gotxt
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.2.1",
 		"@sveltejs/adapter-static": "1.0.0-next.29",
-		"@sveltejs/kit": "1.0.0-next.295",
+		"@sveltejs/kit": "1.0.0-next.301",
 		"@sveltinio/essentials": "^0.1.2",
 		"@sveltinio/seo": "^0.1.5",
 		"@sveltinio/services": "^0.1.2",

--- a/resources/internal/templates/themes/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/scss/package.json.gotxt
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.2.1",
 		"@sveltejs/adapter-static": "1.0.0-next.29",
-		"@sveltejs/kit": "1.0.0-next.295",
+		"@sveltejs/kit": "1.0.0-next.301",
 		"@sveltinio/essentials": "^0.1.2",
 		"@sveltinio/seo": "^0.1.5",
 		"@sveltinio/services": "^0.1.2",

--- a/resources/internal/templates/themes/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/package.json.gotxt
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.2.1",
 		"@sveltejs/adapter-static": "1.0.0-next.29",
-		"@sveltejs/kit": "1.0.0-next.295",
+		"@sveltejs/kit": "1.0.0-next.301",
 		"@sveltinio/essentials": "^0.1.2",
 		"@sveltinio/seo": "^0.1.5",
 		"@sveltinio/services": "^0.1.2",

--- a/resources/internal/templates/themes/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/vanillacss/package.json.gotxt
@@ -16,7 +16,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.2.1",
 		"@sveltejs/adapter-static": "1.0.0-next.29",
-		"@sveltejs/kit": "1.0.0-next.295",
+		"@sveltejs/kit": "1.0.0-next.301",
 		"@sveltinio/essentials": "^0.1.2",
 		"@sveltinio/seo": "^0.1.5",
 		"@sveltinio/services": "^0.1.2",


### PR DESCRIPTION
- sveltekit updated to `next-301`
- `fallthrough` removed from slug templates