### PR TITLE
sveltin TS namespace created

### DIFF
--- a/resources/internal/templates/resource/index.gotxt
+++ b/resources/internal/templates/resource/index.gotxt
@@ -1,6 +1,5 @@
 {{ $varName := .Name | ToVariableName}}
 <script lang="ts">
-	import type { ResourceContent } from '@sveltinio/widgets/types';
 	import { website } from '$config/website.js';
 	import { Card } from '@sveltinio/widgets';
 	import type { IWebPageMetadata } from '@sveltinio/seo/types';
@@ -9,7 +8,7 @@
 	import { ToTitle, getFavicon, getPageUrl } from '$lib/utils/strings.js';
 
 	export let resourceName: string;
-	export let items: Array<ResourceContent>;
+	export let items: Array<Sveltin.ContentEntry>;
 
 	const {{ $varName }}IndexPage: IWebPageMetadata = {
 		url: getPageUrl(resourceName, website),

--- a/resources/internal/templates/resource/index.ts.gotxt
+++ b/resources/internal/templates/resource/index.ts.gotxt
@@ -1,18 +1,17 @@
 import { list } from '$lib/{{ .Name }}/api{{ .Name | ToVariableName | Capitalize }}';
-import { ContentMetadata, ResourceContent, ResourceContentMaker } from '@sveltinio/widgets/types';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function get() {
 	const resourceName = '{{ .Name }}';
 	const data = await list();
 
-	const items: Array<ResourceContent> = [];
+	const items: Array<Sveltin.ContentEntry> = [];
 	data.forEach((elem) => {
-		const item = ResourceContentMaker.createWithValues(
-			resourceName,
-			<ContentMetadata>elem.meta,
-			''
-		);
+		const item: Sveltin.ContentEntry = {
+			resource: resourceName,
+			metadata: <Sveltin.YAMLFrontmatter>elem.meta,
+			html: ''
+		};
 		items.push(item);
 	});
 	return {

--- a/resources/internal/templates/resource/lib.gotxt
+++ b/resources/internal/templates/resource/lib.gotxt
@@ -1,13 +1,10 @@
-import type { DynamicObject } from '$lib/interfaces';
-import { ContentMetadata, ResourceContent, ResourceContentMaker } from '@sveltinio/widgets/types';
-
 export const list = async (withMarkup = false) => {
 	const contentFiles = import.meta.glob('/{{ .Config.Paths.Content }}/{{ .Name }}/**/*.{svelte.md,md,svx}');
 	const contentFilesArray = Object.entries(contentFiles);
 	const contents = await Promise.all(
 		contentFilesArray.map(async ([path, resolver]) => {
 			const data = await resolver();
-			const result: DynamicObject = {
+			const result: Sveltin.DynamicObject = {
 				meta: data.metadata,
 				path: path
 			};
@@ -36,21 +33,21 @@ export const getSingle = async (slug: string) => {
 	if (selected.length != 0) {
 		const selectedItemIndex = publishedByDate.findIndex((elem) => slug === elem.meta.slug);
 		const selectedItem = publishedByDate[selectedItemIndex];
-		const current = ResourceContentMaker.createWithValues(
-			resourceName,
-			selectedItem.meta,
-			selectedItem.markup.html
-		);
-		const previous: ResourceContent = {
+		const current: Sveltin.ContentEntry = {
 			resource: resourceName,
-			metadata: <ContentMetadata>{
+			metadata: selectedItem.meta,
+			html: selectedItem.markup.html
+		};
+		const previous: Sveltin.ContentEntry = {
+			resource: resourceName,
+			metadata: <Sveltin.YAMLFrontmatter>{
 				title: publishedByDate[selectedItemIndex + 1]?.meta.title,
 				slug: publishedByDate[selectedItemIndex + 1]?.meta.slug
 			}
 		};
-		const next: ResourceContent = {
+		const next: Sveltin.ContentEntry = {
 			resource: resourceName,
-			metadata: <ContentMetadata>{
+			metadata: <Sveltin.YAMLFrontmatter>{
 				title: publishedByDate[selectedItemIndex - 1]?.meta.title,
 				slug: publishedByDate[selectedItemIndex - 1]?.meta.slug
 			}

--- a/resources/internal/templates/resource/metadata/index.gotxt
+++ b/resources/internal/templates/resource/metadata/index.gotxt
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import type { Metadata } from '$lib/interfaces';
 
-	export let metadata: Array<Metadata>;
+	export let metadata: Array<Sveltin.ContentMetadata>;
 </script>
 {{ $mdName := .Name | ToVariableName}}
 <div class="artifact-container">

--- a/resources/internal/templates/resource/metadata/index.ts.gotxt
+++ b/resources/internal/templates/resource/metadata/index.ts.gotxt
@@ -1,11 +1,10 @@
 {{ $mdName := .Name | ToVariableName | Capitalize}}
-import type { Metadata } from '$lib/interfaces';
 import { all } from '$lib/{{ .Resource }}/api{{ $mdName }}';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
 export async function get() {
 	const data = await all();
-	const metadata = data as unknown as Array<Metadata>;
+	const metadata = data as unknown as Array<Sveltin.ContentMetadata>;
 	return {
 		status: 200,
 		body: { metadata }

--- a/resources/internal/templates/resource/metadata/libList.gotxt
+++ b/resources/internal/templates/resource/metadata/libList.gotxt
@@ -1,22 +1,21 @@
 {{ $resourceName := .Resource | ToVariableName | Capitalize }}
 {{ $mdName := .Name | ToVariableName }}
 import { groupedByMany } from '$lib/utils/collections.js';
-import type { Metadata, MetadataItem } from '$lib/interfaces';
 import { list } from './api{{ $resourceName }}';
 
-export const all = async (): Promise<Metadata[]> => {
+export const all = async (): Promise<Sveltin.ContentMetadata[]> => {
 	const mdName = '{{ $mdName }}';
 	const data = await list();
 	const values = ['title', 'slug', 'headline'];
 	const grouped = groupedByMany(mdName, data, values);
 
-	const mList: Array<Metadata> = [];
+	const mList: Array<Sveltin.ContentMetadata> = [];
 	grouped.map((elem) => {
-		const metadata: Metadata = {
+		const metadata: Sveltin.ContentMetadata = {
 			name: elem['name'],
 			items: []
 		};
-		elem['items'].forEach((e: MetadataItem) => {
+		elem['items'].forEach((e: Sveltin.YAMLFrontmatter) => {
 			metadata.items.push(e);
 		});
 		mList.push(metadata);
@@ -25,7 +24,7 @@ export const all = async (): Promise<Metadata[]> => {
 	return mList;
 };
 
-export const groupedBy = async (slug: string): Promise<Metadata> => {
+export const groupedBy = async (slug: string): Promise<Sveltin.ContentMetadata> => {
 	const data = await all();
 	const metadata = data.find((item) => {
 		return item.name === slug;

--- a/resources/internal/templates/resource/metadata/libSingle.gotxt
+++ b/resources/internal/templates/resource/metadata/libSingle.gotxt
@@ -1,22 +1,21 @@
 {{ $resourceName := .Resource | ToVariableName | Capitalize }}
 {{ $mdName := .Name | ToVariableName }}
-import type { Metadata, MetadataItem } from '$lib/interfaces';
 import { groupedByOne } from '$lib/utils/collections';
 import { list } from './api{{ $resourceName }}';
 
-export const all = async (): Promise<Metadata[]> => {
+export const all = async (): Promise<Sveltin.ContentMetadata[]> => {
 	const mdName = '{{ $mdName }}';
 	const data = await list();
 	const values = ['title', 'slug', 'headline'];
 	const grouped = groupedByOne(mdName, data, values);
 
-	const mList: Array<Metadata> = [];
+	const mList: Array<Sveltin.ContentMetadata> = [];
 	grouped.map((elem) => {
-		const metadata: Metadata = {
+		const metadata: Sveltin.ContentMetadata = {
 			name: elem['name'],
 			items: []
 		};
-		elem['items'].forEach((e: MetadataItem) => {
+		elem['items'].forEach((e: Sveltin.YAMLFrontmatter) => {
 			metadata.items.push(e);
 		});
 		mList.push(metadata);
@@ -24,7 +23,7 @@ export const all = async (): Promise<Metadata[]> => {
 	return mList;
 };
 
-export const groupedBy = async (slug: string): Promise<Metadata> => {
+export const groupedBy = async (slug: string): Promise<Sveltin.ContentMetadata> => {
 	const data = await all();
 	const metadata = data.find((item) => {
 		return item.name === slug;

--- a/resources/internal/templates/resource/metadata/slug.gotxt
+++ b/resources/internal/templates/resource/metadata/slug.gotxt
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { base } from '$app/paths';
-	import type { Metadata } from '$lib/interfaces';
 
 	export let slug: string;
-	export let metadata: Metadata;
+	export let metadata: Sveltin.ContentMetadata;
 	export let itemsCounter = metadata.items.length;
 </script>
 

--- a/resources/internal/templates/resource/slug.gotxt
+++ b/resources/internal/templates/resource/slug.gotxt
@@ -1,15 +1,14 @@
 <script lang="ts">
 	import { website } from '$config/website.js';
 	import { TOC, PrevNextButtons } from '@sveltinio/widgets';
-	import type { ResourceContent } from '@sveltinio/widgets/types';
 	import { JsonLdWebPage, PageMetaTags, JsonLdBreadcrumbs } from '@sveltinio/seo';
 	import type { IWebPageMetadata } from '@sveltinio/seo/types';
 	import { OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
 	import { getCoverImagePath, getSlugPageUrl } from '$lib/utils/strings.js';
 
-	export let current: ResourceContent;
-	export let previous: ResourceContent;
-	export let next: ResourceContent;
+	export let current: Sveltin.ContentEntry;
+	export let previous: Sveltin.ContentEntry;
+	export let next: Sveltin.ContentEntry;
 
 	const slugPageData: IWebPageMetadata = {
 		url: getSlugPageUrl(current, website),


### PR DESCRIPTION
Sveltin TS namespace created to avoid a direct dependency from `@sveltinio/widgets` interfaces.

In this way, the user can skip the `widget` lib usage preserving a typed approach compatible with the it.