### PR TITLE
resource and metadata endpoints

### DIFF
--- a/cmd/newMetadata.go
+++ b/cmd/newMetadata.go
@@ -67,7 +67,28 @@ func RunNewMetadataCmd(cmd *cobra.Command, args []string) {
 
 	log.Plain(utils.Underline(fmt.Sprintf("'%s' will be created as metadata for %s", mdName, mdResource)))
 
-	// NEW FILE: <metadata_name>.js file into src/lib folder
+	// NEW FILE: <metadata_name>.json.ts
+	log.Info("Creating the API endpoint for the metadata")
+	resourceMetadataAPIFile := &composer.File{
+		Name:       conf.GetMetadataAPIFilename(mdName),
+		TemplateID: Api,
+		TemplateData: &config.TemplateData{
+			Name:     mdName,
+			Resource: mdResource,
+			Type:     mdType,
+			Config:   &conf,
+		},
+	}
+
+	// NEW FOLDER: src/routes/api/<api_version>/<resource_name>
+	resourceAPIFolder := composer.NewFolder(mdResource)
+	resourceAPIFolder.Add(resourceMetadataAPIFile)
+
+	// GET FOLDER: src/routes/api/<api_version> folder
+	apiFolder := fsManager.GetFolder(Api)
+	apiFolder.Add(resourceAPIFolder)
+
+	// NEW FILE: api<metadata_name>.ts file into src/lib/<resource_name> folder
 	log.Info("Creating the lib file for the metadata")
 	libFile := &composer.File{
 		Name:       pathMaker.GetResourceLibFilename(mdName),
@@ -116,6 +137,7 @@ func RunNewMetadataCmd(cmd *cobra.Command, args []string) {
 
 	// SET FOLDER STRUCTURE
 	projectFolder := fsManager.GetFolder(Root)
+	projectFolder.Add(apiFolder)
 	projectFolder.Add(libFolder)
 	projectFolder.Add(routesFolder)
 

--- a/cmd/newResource.go
+++ b/cmd/newResource.go
@@ -40,6 +40,7 @@ This command:
 
 - Create a <resource_name> folder within "content" folder, so that you can add new content for the resource
 - Add the resource as route within the "src/routes" folder, creating its own folder
+- Scaffold a GET endpoint for the resource within "src/routes/api/<api_version>/<resource_name>
 - Scaffold index.svelte component and index.ts endpoint to list all the content belongs to a resource
 - Scaffold [slug].svelte component and [slug].ts endpoint to get access to a specific content page
 	`,
@@ -63,6 +64,25 @@ func RunNewResourceCmd(cmd *cobra.Command, args []string) {
 	log.Info("Creating the content folder for your resource")
 	resourceContentFolder := composer.NewFolder(resourceName)
 	contentFolder.Add(resourceContentFolder)
+
+	// GET FOLDER: src/routes/api/<api_version> folder
+	apiFolder := fsManager.GetFolder(Api)
+
+	// NEW FOLDER: src/routes/api/<version>/<resource_name>
+	resourceAPIFolder := composer.NewFolder(resourceName)
+
+	// NEW FILE: src/routes/api/<resource_name>/published.json.ts
+	log.Info("Creating the API endpoint for the resource")
+	apiFile := &composer.File{
+		Name:       conf.GetAPIFilename(),
+		TemplateID: Api,
+		TemplateData: &config.TemplateData{
+			Name:   resourceName,
+			Config: &conf,
+		},
+	}
+	resourceAPIFolder.Add(apiFile)
+	apiFolder.Add(resourceAPIFolder)
 
 	// GET FOLDER: src/lib folder
 	libFolder := fsManager.GetFolder(Lib)
@@ -107,6 +127,7 @@ func RunNewResourceCmd(cmd *cobra.Command, args []string) {
 	// SET FOLDER STRUCTURE
 	projectFolder := fsManager.GetFolder(Root)
 	projectFolder.Add(contentFolder)
+	projectFolder.Add(apiFolder)
 	projectFolder.Add(libFolder)
 	projectFolder.Add(routesFolder)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,7 @@ const (
 	Config        string = "config"
 	Content       string = "content"
 	Routes        string = "routes"
+	Api           string = "api"
 	Lib           string = "lib"
 	Static        string = "static"
 	Themes        string = "themes"

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -118,14 +118,8 @@ func (c *SveltinConfig) GetPublicAPIFilename() string {
 
 // GetMetadataAPIFilename returns a string representing the path to the 'src/routes/api/v1/<metadata>'
 // folder relative to the current working directory.
-func (c *SveltinConfig) GetMetadataAPIFilename() string {
-	return c.API.Metadata.Filename
-}
-
-// GetPublicMetadataAPIFilename returns a string representing the path to the
-// 'src/routes/api/v1/<metadata>/published.js' file relative to the current working directory.
-func (c *SveltinConfig) GetPublicMetadataAPIFilename() string {
-	return c.API.Metadata.Public
+func (c *SveltinConfig) GetMetadataAPIFilename(mdName string) string {
+	return mdName + ".json.ts"
 }
 
 // GetThemesPath returns a string representing the path to the 'themes' folder

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -74,6 +74,5 @@ func TestAPIs(t *testing.T) {
 	is.Equal("v1", conf.GetAPIVersion())
 	is.Equal("published.json.ts", conf.GetAPIFilename())
 	is.Equal("published.json", conf.GetPublicAPIFilename())
-	is.Equal("groupedBy.json.ts", conf.GetMetadataAPIFilename())
-	is.Equal("groupedBy.json", conf.GetPublicMetadataAPIFilename())
+	is.Equal("category.json.ts", conf.GetMetadataAPIFilename("category"))
 }

--- a/resources/defaults.go
+++ b/resources/defaults.go
@@ -48,6 +48,7 @@ var SveltinProjectFS = map[string]string{
 
 // SveltinResourceFS is a map for the resource template files.
 var SveltinResourceFS = map[string]string{
+	"api":           "internal/templates/resource/api.gotxt",
 	"lib":           "internal/templates/resource/lib.gotxt",
 	"index":         "internal/templates/resource/index.gotxt",
 	"indexendpoint": "internal/templates/resource/index.ts.gotxt",
@@ -57,6 +58,8 @@ var SveltinResourceFS = map[string]string{
 
 // SveltinMetadataFS is a map for the metadata template files.
 var SveltinMetadataFS = map[string]string{
+	"api_single":    "internal/templates/resource/metadata/apiSingle.gotxt",
+	"api_list":      "internal/templates/resource/metadata/apiList.gotxt",
 	"lib_single":    "internal/templates/resource/metadata/libSingle.gotxt",
 	"lib_list":      "internal/templates/resource/metadata/libList.gotxt",
 	"index":         "internal/templates/resource/metadata/index.gotxt",

--- a/resources/defaults_test.go
+++ b/resources/defaults_test.go
@@ -31,6 +31,7 @@ func TestSveltinSiteFS(t *testing.T) {
 
 func TestSveltinResourceFS(t *testing.T) {
 	is := is.New(t)
+	is.Equal("internal/templates/resource/api.gotxt", SveltinResourceFS["api"])
 	is.Equal("internal/templates/resource/lib.gotxt", SveltinResourceFS["lib"])
 	is.Equal("internal/templates/resource/index.gotxt", SveltinResourceFS["index"])
 	is.Equal("internal/templates/resource/index.ts.gotxt", SveltinResourceFS["indexendpoint"])
@@ -40,7 +41,10 @@ func TestSveltinResourceFS(t *testing.T) {
 
 func TestSveltinMetadataFS(t *testing.T) {
 	is := is.New(t)
+	is.Equal("internal/templates/resource/metadata/apiSingle.gotxt", SveltinMetadataFS["api_single"])
 	is.Equal("internal/templates/resource/metadata/libSingle.gotxt", SveltinMetadataFS["lib_single"])
+	is.Equal("internal/templates/resource/metadata/apiList.gotxt", SveltinMetadataFS["api_list"])
+	is.Equal("internal/templates/resource/metadata/libList.gotxt", SveltinMetadataFS["lib_list"])
 	is.Equal("internal/templates/resource/metadata/index.gotxt", SveltinMetadataFS["index"])
 	is.Equal("internal/templates/resource/metadata/index.ts.gotxt", SveltinMetadataFS["indexendpoint"])
 	is.Equal("internal/templates/resource/metadata/slug.gotxt", SveltinMetadataFS["slug"])

--- a/resources/internal/templates/resource/api.gotxt
+++ b/resources/internal/templates/resource/api.gotxt
@@ -1,0 +1,24 @@
+import { list, getSingle  } from '$lib/{{ .Name }}/api{{ .Name | ToVariableName | Capitalize }}';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function get({ url }) {
+	const searchFor = 'slug';
+	const slug = url.searchParams.get(searchFor);
+
+	if (slug) {
+		const data = await getSingle(slug);
+		return {
+			status: 200,
+			body: JSON.stringify(data)
+		};
+	} else {
+		const data = await list();
+		const body = data.map((item) => ({
+			...item
+		}));
+		return {
+			status: 200,
+			body: JSON.stringify(body)
+		};
+	}
+}

--- a/resources/internal/templates/resource/metadata/apiList.gotxt
+++ b/resources/internal/templates/resource/metadata/apiList.gotxt
@@ -1,0 +1,24 @@
+import { all, groupedBy } from '$lib/{{ .Resource }}/api{{ .Name | ToVariableName | Capitalize }}';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function get({ url }) {
+	const searchFor = 'name';
+	const slug = url.searchParams.get(searchFor);
+
+	if (slug) {
+		const data = await groupedBy(slug);
+		return {
+			status: 200,
+			body: JSON.stringify(data)
+		};
+	} else {
+		const data = await all();
+		const body = data.map((item) => ({
+			...item
+		}));
+		return {
+			status: 200,
+			body: JSON.stringify(body)
+		};
+	}
+}

--- a/resources/internal/templates/resource/metadata/apiSingle.gotxt
+++ b/resources/internal/templates/resource/metadata/apiSingle.gotxt
@@ -1,0 +1,24 @@
+import { all, groupedBy } from '$lib/{{ .Resource }}/api{{ .Name | ToVariableName | Capitalize }}';
+
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function get({ url }) {
+	const searchFor = 'name';
+	const slug = url.searchParams.get(searchFor);
+
+	if (slug) {
+		const data = await groupedBy(slug);
+		return {
+			status: 200,
+			body: JSON.stringify(data)
+		};
+	} else {
+		const data = await all();
+		const body = data.map((item) => ({
+			...item
+		}));
+		return {
+			status: 200,
+			body: JSON.stringify(body)
+		};
+	}
+}

--- a/sveltinlib/builder/constants.go
+++ b/sveltinlib/builder/constants.go
@@ -35,6 +35,13 @@ const (
 
 	// API is a string for the 'api' folder.
 	API string = "api"
+	// APISingle is a string representing the api template file
+	// to be used when creating a metadata of type 'single'.
+	APISingle string = "api_single"
+	// APIList is a string representing the api template file
+	// to be used when creating a metadata of type 'list'.
+	APIList string = "api_list"
+
 	// Index is a string for the 'index' file.
 	Index string = "index"
 	// IndexEndpoint is a string for the 'index.ts' file.

--- a/sveltinlib/builder/metadata_builder.go
+++ b/sveltinlib/builder/metadata_builder.go
@@ -43,6 +43,13 @@ func (b *MetadataContentBuilder) SetEmbeddedResources(res map[string]string) {
 
 func (b *MetadataContentBuilder) setPathToTplFile() error {
 	switch b.TemplateID {
+	case API:
+		if b.TemplateData.Type == "single" {
+			b.PathToTplFile = b.EmbeddedResources[APISingle]
+		} else if b.TemplateData.Type == "list" {
+			b.PathToTplFile = b.EmbeddedResources[APIList]
+		}
+		return nil
 	case Index:
 		b.PathToTplFile = b.EmbeddedResources[Index]
 		return nil


### PR DESCRIPTION
Reintroducing resource and metadata endpoints.

Before moving to SvelteKit Page Endpoints (**sveltin v0.6.0**) there was an endpoint under `api/v1/` to get data for resources. That endpoint was removed with the `page endpoint` introduction.

This PR, introduces REST endpoints again for _resources_ and _metadata_. For development and testing I found easier get access to the data with simple REST calls.

```bash
curl http://localhost:<port_number>/api/v1/<resource_name>/published.json
curl http://localhost:<port_number>/api/v1/<resource_name>/published.json?slug=<value>

curl http://localhost:<port_number>/api/v1/<resource_name>/<metadata_name>.json
curl http://localhost:<port_number>/api/v1/<resource_name>/<metadata_name>.json?name=<value>
...
```
