### PR TITLE
fix: resource and metadata names to kebab case

### DIFF
--- a/pkg/builder/metadata_builder.go
+++ b/pkg/builder/metadata_builder.go
@@ -96,6 +96,9 @@ func (b *MetadataContentBuilder) setFuncs() {
 		"ToLibFile": func(txt string) string {
 			return utils.ToLibFile(txt)
 		},
+		"ToSnakeCase": func(txt string) string {
+			return utils.ToSnakeCase(txt)
+		},
 	}
 }
 

--- a/pkg/builder/resource_builder.go
+++ b/pkg/builder/resource_builder.go
@@ -88,6 +88,9 @@ func (b *ResourceContentBuilder) setFuncs() {
 		"ToLibFile": func(txt string) string {
 			return utils.ToLibFile(txt)
 		},
+		"ToSlug": func(txt string) string {
+			return utils.ToSlug(txt)
+		},
 	}
 }
 

--- a/resources/internal/templates/resource/lib.gotxt
+++ b/resources/internal/templates/resource/lib.gotxt
@@ -21,9 +21,9 @@ export const list = async (withMarkup = false) => {
 	return publishedByDate;
 };
 
-{{ $varName := .Name | ToVariableName}}
+{{ $slugName := .Name | ToSlug}}
 export const getSingle = async (slug: string) => {
-	const resourceName = '{{ $varName }}';
+	const resourceName = '{{ $slugName }}';
 	const publishedByDate = await list(true);
 
 	const selected = publishedByDate.filter((item) => {

--- a/resources/internal/templates/resource/metadata/libList.gotxt
+++ b/resources/internal/templates/resource/metadata/libList.gotxt
@@ -1,5 +1,5 @@
 {{ $resourceName := .Resource | ToVariableName | Capitalize }}
-{{ $mdName := .Name | ToVariableName }}
+{{ $mdName := .Name | ToSnakeCase }}
 import { groupedByMany } from '$lib/utils/collections.js';
 import { list } from './api{{ $resourceName }}';
 

--- a/resources/internal/templates/resource/metadata/libSingle.gotxt
+++ b/resources/internal/templates/resource/metadata/libSingle.gotxt
@@ -1,5 +1,5 @@
 {{ $resourceName := .Resource | ToVariableName | Capitalize }}
-{{ $mdName := .Name | ToVariableName }}
+{{ $mdName := .Name | ToSnakeCase }}
 import { groupedByOne } from '$lib/utils/collections';
 import { list } from './api{{ $resourceName }}';
 

--- a/utils/text.go
+++ b/utils/text.go
@@ -74,6 +74,16 @@ func ToSlug(txt string) string {
 	return cleanString
 }
 
+// ToSnakeCase returns a copy of string with lowercase
+// replacing "_" and whitespaces with "_"
+// example: ToSnakeCase("New Resource") returns new_resource.
+func ToSnakeCase(txt string) string {
+	cleanString := strings.ToLower(txt)
+	cleanString = strings.ReplaceAll(cleanString, " ", "_")
+	cleanString = strings.ReplaceAll(cleanString, "-", "_")
+	return cleanString
+}
+
 // ToBasePath returns a copy of string replacing all occurrences
 // for a string with trailing slash.
 func ToBasePath(fullpath string, replace string) string {


### PR DESCRIPTION
this fixes the issues with lib and api when a resource name or a metadata name are multiple words in kebab or snake cases