### PR TITLE
Pin vite-plugin-svelte to 1.0.0-next.49

### DIFF
--- a/resources/internal/templates/themes/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/bootstrap/package.json.gotxt
@@ -18,7 +18,7 @@
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@popperjs/core": "^2.11.5",
 		"@sveltejs/adapter-static": "1.0.0-next.35",
-		"@sveltejs/kit": "1.0.0-next.370",
+		"@sveltejs/kit": "1.0.0-next.371",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/bulma/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.35",
-		"@sveltejs/kit": "1.0.0-next.370",
+		"@sveltejs/kit": "1.0.0-next.371",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/scss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.35",
-		"@sveltejs/kit": "1.0.0-next.370",
+		"@sveltejs/kit": "1.0.0-next.371",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.35",
-		"@sveltejs/kit": "1.0.0-next.370",
+		"@sveltejs/kit": "1.0.0-next.371",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/vanillacss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.35",
-		"@sveltejs/kit": "1.0.0-next.370",
+		"@sveltejs/kit": "1.0.0-next.371",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",


### PR DESCRIPTION
It fixes [#5495](https://github.com/sveltejs/kit/issues/5495) on svelte-kit.

Vite v3 has been released and `vite-plugin-svelte` works on Vite 3 already.
Svelte-Kit does not yet, until [#5005](https://github.com/sveltejs/kit/pull/5005) will be reviewd and merged.
