### PR TITLE
git-chglog-tpl updated

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -18,8 +18,6 @@
 
 ## [{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/releases/tag/{{ .Tag.Name }}) ({{ datetime "2006-01-02" .Tag.Date }})
 
-{{ if .Tag.Previous }}[Full Changelog]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
-
 {{ range .CommitGroups -}}
 
 ### {{ .Title }}
@@ -55,5 +53,6 @@
 {{ end }}
 {{ end -}}
 {{ end -}}
-{{ end -}}
 
+{{ if .Tag.Previous }}[Full Changelog]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -22,16 +22,16 @@ options:
       - refactor
       - perf
       - ci
-      - docs
       - chore
+      - docs
     title_maps:
       feat: 🚀  New Features
       fix: Fixed Bugs
       perf: 🚄  Performance Improvements
       refactor: 🔧  Code Refactoring
-      docs: 📖  Documentation
       chore: Chores
       ci: ⚙️  CI
+      docs: 📖  Documentation
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:


### PR DESCRIPTION
- Reordering sections (documentation is the last one)
- Moving **Full Changelog** section at the bottom of the changelog