### PR TITLE
chore: vite3

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -188,7 +188,7 @@ func newCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&npmClientName, "npmClient", "n", "", "The name of your preferred npm client")
 	cmd.Flags().StringVarP(&withThemeName, "theme", "t", "", "The theme you are going to create or reuse")
 	cmd.Flags().StringVarP(&withCSSLib, "css", "c", "", "The name of the CSS framework to use. Valid: vanillacss, tailwindcss, bulma, bootstrap, scss")
-	cmd.Flags().StringVarP(&withPortNumber, "port", "p", "3000", "The port to start the server on")
+	cmd.Flags().StringVarP(&withPortNumber, "port", "p", "5173", "The port to start the server on")
 	cmd.Flags().BoolVarP(&withGit, "git", "g", false, "Initialize an empty Git repository")
 }
 

--- a/resources/internal/templates/themes/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/bootstrap/package.json.gotxt
@@ -18,7 +18,7 @@
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@popperjs/core": "^2.11.5",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.373",
+		"@sveltejs/kit": "1.0.0-next.375",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/bootstrap/package.json.gotxt
@@ -18,7 +18,7 @@
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@popperjs/core": "^2.11.5",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.371",
+		"@sveltejs/kit": "1.0.0-next.373",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",
@@ -54,7 +54,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.7.4",
 		"unist-util-visit": "^4.1.0",
-		"vite": "^2.9.13"
+		"vite": "^3.0.0"
 	},
 	"type": "module"
 }

--- a/resources/internal/templates/themes/bootstrap/vite.config.js.gotxt
+++ b/resources/internal/templates/themes/bootstrap/vite.config.js.gotxt
@@ -8,6 +8,7 @@ const json = readFileSync(file, 'utf8');
 const pkg = JSON.parse(json);
 /** @type {import('vite').UserConfig} */
 const config = {
+	clearScreen: false,
 	define: {
 		'process.env.VITE_SVELTEKIT_VERSION': JSON.stringify(
 			String(pkg.devDependencies['@sveltejs/kit'])

--- a/resources/internal/templates/themes/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/bulma/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.373",
+		"@sveltejs/kit": "1.0.0-next.375",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/bulma/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.371",
+		"@sveltejs/kit": "1.0.0-next.373",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",
@@ -53,7 +53,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.7.4",
 		"unist-util-visit": "^4.1.0",
-		"vite": "^2.9.13"
+		"vite": "^3.0.0"
 	},
 	"type": "module"
 }

--- a/resources/internal/templates/themes/bulma/vite.config.js.gotxt
+++ b/resources/internal/templates/themes/bulma/vite.config.js.gotxt
@@ -10,6 +10,7 @@ const pkg = JSON.parse(json);
 /** @type {import('vite').UserConfig} */
 const config = {
 	define: {
+		clearScreen: false,
 		'process.env.VITE_SVELTEKIT_VERSION': JSON.stringify(
 			String(pkg.devDependencies['@sveltejs/kit'])
 		),

--- a/resources/internal/templates/themes/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/scss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.373",
+		"@sveltejs/kit": "1.0.0-next.375",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/scss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.371",
+		"@sveltejs/kit": "1.0.0-next.373",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",
@@ -52,7 +52,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.7.4",
 		"unist-util-visit": "^4.1.0",
-		"vite": "^2.9.13"
+		"vite": "^3.0.0"
 	},
 	"type": "module"
 }

--- a/resources/internal/templates/themes/scss/vite.config.js.gotxt
+++ b/resources/internal/templates/themes/scss/vite.config.js.gotxt
@@ -9,6 +9,7 @@ const pkg = JSON.parse(json);
 
 /** @type {import('vite').UserConfig} */
 const config = {
+	clearScreen: false,
 	define: {
 		'process.env.VITE_SVELTEKIT_VERSION': JSON.stringify(
 			String(pkg.devDependencies['@sveltejs/kit'])

--- a/resources/internal/templates/themes/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.373",
+		"@sveltejs/kit": "1.0.0-next.375",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.371",
+		"@sveltejs/kit": "1.0.0-next.373",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",
@@ -62,7 +62,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.7.4",
 		"unist-util-visit": "^4.1.0",
-		"vite": "^2.9.13"
+		"vite": "^3.0.0"
 	},
 	"type": "module"
 }

--- a/resources/internal/templates/themes/tailwindcss/vite.config.js.gotxt
+++ b/resources/internal/templates/themes/tailwindcss/vite.config.js.gotxt
@@ -9,6 +9,7 @@ const pkg = JSON.parse(json);
 
 /** @type {import('vite').UserConfig} */
 const config = {
+	clearScreen: false,
 	define: {
 		'process.env.VITE_SVELTEKIT_VERSION': JSON.stringify(
 			String(pkg.devDependencies['@sveltejs/kit'])

--- a/resources/internal/templates/themes/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/vanillacss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.373",
+		"@sveltejs/kit": "1.0.0-next.375",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/vanillacss/package.json.gotxt
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@indaco/svelte-iconoir": "^2.5.1",
 		"@sveltejs/adapter-static": "1.0.0-next.36",
-		"@sveltejs/kit": "1.0.0-next.371",
+		"@sveltejs/kit": "1.0.0-next.373",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",
@@ -51,7 +51,7 @@
 		"tslib": "^2.4.0",
 		"typescript": "^4.7.4",
 		"unist-util-visit": "^4.1.0",
-		"vite": "^2.9.13"
+		"vite": "^3.0.0"
 	},
 	"type": "module"
 }

--- a/resources/internal/templates/themes/vanillacss/vite.config.js.gotxt
+++ b/resources/internal/templates/themes/vanillacss/vite.config.js.gotxt
@@ -9,6 +9,7 @@ const pkg = JSON.parse(json);
 
 /** @type {import('vite').UserConfig} */
 const config = {
+	clearScreen: false,
 	define: {
 		'process.env.VITE_SVELTEKIT_VERSION': JSON.stringify(
 			String(pkg.devDependencies['@sveltejs/kit'])


### PR DESCRIPTION
- chore: update to sveltekit-next.373 with Vite3 support
- chore(vite.config.js): clearScreen:false to prevent Vite from clearing the terminal
- fix(cmd/new.go): the default dev server port is now 5173
- chore: sveltekit updated to next.375
