### PR TITLE
uppercase endpoint methods

### DIFF
--- a/resources/internal/templates/resource/api/apiIndex.gotxt
+++ b/resources/internal/templates/resource/api/apiIndex.gotxt
@@ -1,7 +1,7 @@
 import { list } from '$lib/posts/apiPosts';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get() {
+export async function GET() {
 	const data = await list();
 	const body = data.map((item) => ({
 		...item

--- a/resources/internal/templates/resource/api/apiMetadataIndex.gotxt
+++ b/resources/internal/templates/resource/api/apiMetadataIndex.gotxt
@@ -1,7 +1,7 @@
 import { all } from '$lib/{{ .Resource }}/api{{ .Name | ToVariableName | Capitalize }}';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get() {
+export async function GET() {
 	const data = await all();
 	const body = data.map((item) => ({
 		...item

--- a/resources/internal/templates/resource/index.ts.gotxt
+++ b/resources/internal/templates/resource/index.ts.gotxt
@@ -2,7 +2,7 @@ import type { Sveltin } from 'src/sveltin';
 import { list } from '$lib/{{ .Name }}/api{{ .Name | ToVariableName | Capitalize }}';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get() {
+export async function GET() {
 	const resourceName = '{{ .Name }}';
 	const data = await list();
 

--- a/resources/internal/templates/resource/metadata/index.ts.gotxt
+++ b/resources/internal/templates/resource/metadata/index.ts.gotxt
@@ -3,7 +3,7 @@ import type { Sveltin } from 'src/sveltin';
 import { all } from '$lib/{{ .Resource }}/api{{ $mdName }}';
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get() {
+export async function GET() {
 	const data = await all();
 	const metadata = data as unknown as Array<Sveltin.ContentMetadata>;
 	return {

--- a/resources/internal/templates/resource/metadata/slug.ts.gotxt
+++ b/resources/internal/templates/resource/metadata/slug.ts.gotxt
@@ -2,7 +2,7 @@
 import { groupedBy } from '$lib/{{ .Resource }}/api{{ $mdName }}';
 
 /** @type {import('./[slug]').RequestHandler} */
-export async function get({ params }) {
+export async function GET({ params }) {
 	const metadata = await groupedBy(params.slug);
 	if (metadata) {
 		return {

--- a/resources/internal/templates/resource/slug.ts.gotxt
+++ b/resources/internal/templates/resource/slug.ts.gotxt
@@ -1,7 +1,7 @@
 import { getSingle } from '$lib/{{ .Name }}/api{{ .Name | ToVariableName | Capitalize }}';
 
 /** @type {import('./[slug]').RequestHandler} */
-export async function get({ params }) {
+export async function GET({ params }) {
 	const { status, current, previous, next } = await getSingle(params.slug);
 
 	if (status === 200) {

--- a/resources/internal/templates/xml/ssr_rss.xml.ts.gotxt
+++ b/resources/internal/templates/xml/ssr_rss.xml.ts.gotxt
@@ -1,7 +1,8 @@
 import { variables } from '$lib/Env.js';
 import { website } from '$config/website.js';
 
-export async function get() {
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
 	{{ range $res := .Resources }}
 	const {{ $res }}URL = `${variables.basePath}/api/v1/{{ $res }}/published.json`;
 	const {{ $res }}Request = await fetch({{ $res }}URL);

--- a/resources/internal/templates/xml/ssr_sitemap.xml.ts.gotxt
+++ b/resources/internal/templates/xml/ssr_sitemap.xml.ts.gotxt
@@ -2,7 +2,8 @@
 import { variables } from '$lib/Env.js';
 import { website } from '$config/website.js';
 
-export async function get() {
+/** @type {import('@sveltejs/kit').RequestHandler} */
+export async function GET() {
 	{{ range $res := .Resources }}
 	const {{ $res }}URL = `${variables.basePath}/api/v1/{{ $res }}/published.json`;
 	const {{ $res }}Request = await fetch({{ $res }}URL);


### PR DESCRIPTION
This fixes the breaking introduced on [kit@1.0.0-next.377](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%401.0.0-next.377):

- Endpoint method names uppercased to match HTTP specifications.


