### PR TITLE
release 0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed Bugs
 
 - avoid typescript linting errors
-- param matchers name when '-' in resource and metadata name
+- [#68](https://github.com/sveltinio/sveltin/issues/68) param matchers name when '-' in resource and metadata name
 - update to sveltekit next.377 with uppercase endpoint methods
 - **apiIndex:** wrong import string
 
@@ -16,6 +16,13 @@
 - update to afero 1.9.0
 - unused files for xml generation as endpoints removed
 - uppercase endpoint methods as per sveltekit next.377
+
+### Pull Requests
+
+- Merge pull request [#65](https://github.com/sveltinio/sveltin/issues/65) from sveltinio/sveltekit-next-377
+- Merge pull request [#66](https://github.com/sveltinio/sveltin/issues/66) from sveltinio/remove-unused-files
+- Merge pull request [#67](https://github.com/sveltinio/sveltin/issues/69) from sveltinio/afero-update
+- Merge pull request [#69](https://github.com/sveltinio/sveltin/issues/69) from sveltinio/fix-matcher-names
 
 ## [v0.8.9](https://github.com/sveltinio/sveltin/releases/tag/v0.8.9) (2022-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG
 
+## [v0.8.10](https://github.com/sveltinio/sveltin/releases/tag/v0.8.10) (2022-07-16)
+
+[Full Changelog](https://github.com/sveltinio/sveltin/compare/v0.8.9...v0.8.10)
+
+### Fixed Bugs
+
+- avoid typescript linting errors
+- param matchers name when '-' in resource and metadata name
+- update to sveltekit next.377 with uppercase endpoint methods
+- **apiIndex:** wrong import string
+
+### Chores
+
+- update to afero 1.9.0
+- unused files for xml generation as endpoints removed
+- uppercase endpoint methods as per sveltekit next.377
+
 ## [v0.8.9](https://github.com/sveltinio/sveltin/releases/tag/v0.8.9) (2022-07-15)
 
 [Full Changelog](https://github.com/sveltinio/sveltin/compare/v0.8.8...v0.8.9)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Smartest Way to Build SvelteKit powered static websites.
     </a>
     &nbsp;
     <a href="https://github.com/sveltinio/sveltin/releases" target="_blank">
-        <img src="https://img.shields.io/badge/version-v0.8.9-success?style=flat-square&logo=none" alt="sveltin cli version" />
+        <img src="https://img.shields.io/badge/version-v0.8.10-success?style=flat-square&logo=none" alt="sveltin cli version" />
     </a>
     &nbsp;
     <a href="https://github.com/sveltinio/sveltin/actions/workflows/release.yml" target="_blank">
@@ -50,7 +50,7 @@ Sveltin is a CLI (Command Line Interface) created to boost the developers produc
 
 ## :warning: Project Status
 
-> Sveltin is under active development and some changes are expected before we hit version 1.0. At the same time, we will do our best to follow the progress toward SvelteKit v1.0 (Latest SvelteKit tested version is **1.0.0-next-375**). If you are interesting on it please, give it a try and let it evolves, see the **Contributing** section. If you get stuck, reach out for help in the [discussions tab](https://github.com/sveltinio/sveltin/discussions) or open an [issue](https://github.com/sveltinio/sveltin/issues).
+> Sveltin is under active development and some changes are expected before we hit version 1.0. At the same time, we will do our best to follow the progress toward SvelteKit v1.0 (Latest SvelteKit tested version is **1.0.0-next-377**). If you are interesting on it please, give it a try and let it evolves, see the **Contributing** section. If you get stuck, reach out for help in the [discussions tab](https://github.com/sveltinio/sveltin/discussions) or open an [issue](https://github.com/sveltinio/sveltin/issues).
 
 ## :mega: Overview
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ type appConfig struct {
 
 const (
 	// CliVersion is the current sveltin cli version number.
-	CliVersion string = "0.8.9"
+	CliVersion string = "0.8.10"
 	// SvelteKitStarter is a string representing the project starter id.
 	SvelteKitStarter string = "starter"
 	// ThemeStarter is a string representing the project starter id for new themes.


### PR DESCRIPTION
### Fixed Bugs

- avoid typescript linting errors
- [#68](https://github.com/sveltinio/sveltin/issues/68) param matchers name when '-' in resource and metadata name
- update to sveltekit next.377 with uppercase endpoint methods
- **apiIndex:** wrong import string

### Chores

- update to afero 1.9.0
- unused files for xml generation as endpoints removed
- uppercase endpoint methods as per sveltekit next.377

### Pull Requests

- Merge pull request [#65](https://github.com/sveltinio/sveltin/issues/65) from sveltinio/sveltekit-next-377
- Merge pull request [#66](https://github.com/sveltinio/sveltin/issues/66) from sveltinio/remove-unused-files
- Merge pull request [#67](https://github.com/sveltinio/sveltin/issues/69) from sveltinio/afero-update
- Merge pull request [#69](https://github.com/sveltinio/sveltin/issues/69) from sveltinio/fix-matcher-names

**Full Changelog**: https://github.com/sveltinio/sveltin/compare/v0.8.9...v0.8.10
