### PR TITLE
add error page when create a project

### DIFF
--- a/internal/css/constants.go
+++ b/internal/css/constants.go
@@ -27,6 +27,7 @@ const (
 	AppCSSFileID         string = "app_css"
 	VariablesFileID      string = "variables_scss"
 	LayoutFileID         string = "layout"
+	ErrorFileID          string = "error"
 	SvelteConfigFileID   string = "svelte_config"
 	ViteConfigFileID     string = "vite_config"
 	HeroFileID           string = "hero"

--- a/internal/css/cssframework.go
+++ b/internal/css/cssframework.go
@@ -102,6 +102,16 @@ func makeSveltinStyled(cssLib *CSSLib) error {
 	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
 		return err
 	}
+
+	// Copying +error.svelte. file
+	sourceFile = embeddedResources[ErrorFileID]
+	template = helpers.BuildTemplate(sourceFile, nil, cssLib.TplData)
+	content = template.Run(cssLib.EFS)
+	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "src", "routes", "+error.svelte")
+	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
+		return err
+	}
+
 	// Copying Hero.svelte component
 	sourceFile = embeddedResources[HeroFileID]
 	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "themes", cssLib.TplData.Theme.Name, "partials", "Hero.svelte")
@@ -172,6 +182,16 @@ func makeUnstyled(cssLib *CSSLib) error {
 	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
 		return err
 	}
+
+	// Copying +error.svelte. file
+	sourceFile = embeddedResources[ErrorFileID]
+	template = helpers.BuildTemplate(sourceFile, nil, cssLib.TplData)
+	content = template.Run(cssLib.EFS)
+	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "src", "routes", "+error.svelte")
+	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
+		return err
+	}
+
 	// Copying Hero.svelte component
 	sourceFile = embeddedResources[HeroFileID]
 	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "themes", cssLib.TplData.Theme.Name, "partials", "Hero.svelte")
@@ -232,6 +252,15 @@ func makeTheme(cssLib *CSSLib) error {
 	template = helpers.BuildTemplate(sourceFile, nil, cssLib.TplData)
 	content = template.Run(cssLib.EFS)
 	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "src", "routes", "+layout.svelte")
+	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
+		return err
+	}
+
+	// Copying +error.svelte. file
+	sourceFile = embeddedResources[ErrorFileID]
+	template = helpers.BuildTemplate(sourceFile, nil, cssLib.TplData)
+	content = template.Run(cssLib.EFS)
+	saveAs = filepath.Join(cssLib.Config.GetProjectRoot(), cssLib.TplData.ProjectName, "src", "routes", "+error.svelte")
 	if err := helpers.WriteContentToDisk(cssLib.FS, saveAs, content); err != nil {
 		return err
 	}

--- a/resources/defaults.go
+++ b/resources/defaults.go
@@ -118,6 +118,7 @@ var SveltinVanillaStyledFS = SveltinFSItem{
 	"app_css": "internal/templates/themes/vanillacss/styled/app.css",
 	"hero":    "internal/templates/themes/vanillacss/styled/Hero.svelte",
 	"footer":  "internal/templates/themes/vanillacss/styled/Footer.svelte",
+	"error":   "internal/templates/themes/error.styled.svelte",
 }
 
 // SveltinVanillaUnstyledFS is the map for the unstyled templates file whe using vanilla css.
@@ -125,6 +126,7 @@ var SveltinVanillaUnstyledFS = SveltinFSItem{
 	"layout":  "internal/templates/themes/vanillacss/unstyled/layout.svelte.gotxt",
 	"app_css": "internal/templates/themes/vanillacss/unstyled/app.css",
 	"hero":    "internal/templates/themes/vanillacss/unstyled/Hero.svelte",
+	"error":   "internal/templates/themes/error.unstyled.svelte",
 }
 
 //=============================================================================
@@ -145,6 +147,7 @@ var SveltinTailwindLibStyledFS = SveltinFSItem{
 	"app_css":             "internal/templates/themes/tailwindcss/styled/app.css",
 	"hero":                "internal/templates/themes/tailwindcss/styled/Hero.svelte",
 	"footer":              "internal/templates/themes/tailwindcss/styled/Footer.svelte",
+	"error":               "internal/templates/themes/error.styled.svelte",
 }
 
 // SveltinTailwindLibUnstyledFS is the map for the unstyled templates file whe using tailwind css.
@@ -153,6 +156,7 @@ var SveltinTailwindLibUnstyledFS = SveltinFSItem{
 	"tailwind_css_config": "internal/templates/themes/tailwindcss/unstyled/tailwind.config.cjs",
 	"app_css":             "internal/templates/themes/tailwindcss/unstyled/app.css",
 	"hero":                "internal/templates/themes/tailwindcss/unstyled/Hero.svelte",
+	"error":               "internal/templates/themes/error.unstyled.svelte",
 }
 
 //=============================================================================
@@ -172,6 +176,7 @@ var SveltinBulmaLibStyledFS = SveltinFSItem{
 	"variables_scss": "internal/templates/themes/bulma/styled/variables.scss",
 	"hero":           "internal/templates/themes/bulma/styled/Hero.svelte",
 	"footer":         "internal/templates/themes/bulma/styled/Footer.svelte",
+	"error":          "internal/templates/themes/error.styled.svelte",
 }
 
 // SveltinBulmaLibUnstyledFS is the map for the unstyled templates file whe using bulma.
@@ -180,6 +185,7 @@ var SveltinBulmaLibUnstyledFS = SveltinFSItem{
 	"app_css":        "internal/templates/themes/bulma/unstyled/app.scss",
 	"variables_scss": "internal/templates/themes/bulma/unstyled/variables.scss",
 	"hero":           "internal/templates/themes/bulma/unstyled/Hero.svelte",
+	"error":          "internal/templates/themes/error.unstyled.svelte",
 }
 
 //=============================================================================
@@ -199,6 +205,7 @@ var SveltinBootstrapLibStyledFS = SveltinFSItem{
 	"variables_scss": "internal/templates/themes/bootstrap/styled/variables.scss",
 	"hero":           "internal/templates/themes/bootstrap/styled/Hero.svelte",
 	"footer":         "internal/templates/themes/bootstrap/styled/Footer.svelte",
+	"error":          "internal/templates/themes/error.styled.svelte",
 }
 
 // SveltinBootstrapLibUnstyledFS is the map for the unstyled templates file whe using bootstrap.
@@ -207,6 +214,7 @@ var SveltinBootstrapLibUnstyledFS = SveltinFSItem{
 	"app_css":        "internal/templates/themes/bootstrap/unstyled/app.scss",
 	"variables_scss": "internal/templates/themes/bootstrap/unstyled/variables.scss",
 	"hero":           "internal/templates/themes/bootstrap/unstyled/Hero.svelte",
+	"error":          "internal/templates/themes/error.unstyled.svelte",
 }
 
 //=============================================================================
@@ -226,6 +234,7 @@ var SveltinSCSSLibStyledFS = SveltinFSItem{
 	"variables_scss": "internal/templates/themes/scss/styled/variables.scss",
 	"hero":           "internal/templates/themes/scss/styled/Hero.svelte",
 	"footer":         "internal/templates/themes/scss/styled/Footer.svelte",
+	"error":          "internal/templates/themes/error.styled.svelte",
 }
 
 // SveltinSCSSLibUnstyledFS is the map for the unstyled templates file whe using scss/sass.
@@ -234,4 +243,5 @@ var SveltinSCSSLibUnstyledFS = SveltinFSItem{
 	"app_css":        "internal/templates/themes/scss/unstyled/app.scss",
 	"variables_scss": "internal/templates/themes/scss/unstyled/variables.scss",
 	"hero":           "internal/templates/themes/scss/unstyled/Hero.svelte",
+	"error":          "internal/templates/themes/error.unstyled.svelte",
 }

--- a/resources/internal/templates/themes/error.styled.svelte
+++ b/resources/internal/templates/themes/error.styled.svelte
@@ -1,0 +1,117 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<svelte:head>
+	<title>{$page.status}: {$page.error.message}</title>
+</svelte:head>
+<div class="error-container">
+	<div class="wrapper">
+		<main class="main">
+			<p class="error-code">{$page.status}</p>
+			<div class="message-wrapper">
+				<div class="message-main">
+					<h1 class="error-title">
+						{$page.error.message}
+					</h1>
+					<p class="error-text">
+						Please check the URL in the address bar and try again.
+					</p>
+				</div>
+			</div>
+		</main>
+	</div>
+</div>
+
+<style>
+	.error-container {
+		min-height: 100%;
+		padding-top: 4rem;
+		padding-right: 1rem;
+		padding-bottom: 4rem;
+		padding-left: 1rem;
+	}
+
+	.wrapper {
+		max-width: max-content;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	.main {
+		justify-content: center;
+		align-items: center;
+	}
+
+	.error-code {
+		font-size: 2.25rem;
+		line-height: 2.5rem;
+		font-weight: 800;
+		color: #0b7599;
+	}
+
+	.error-title {
+		font-size: 2.25rem;
+		line-height: 2.5rem;
+		font-weight: 800;
+		color: #374151;
+		letter-spacing: -0.025em;
+	}
+
+	.error-text {
+		margin-top: 0.25rem;
+		font-size: 1rem;
+		line-height: 1.5rem;
+		color: #6b7280;
+	}
+
+	@media (min-width: 640px) {
+		.error-title {
+			font-size: 3rem;
+			line-height: 1;
+		}
+		.error-container {
+			padding-left: 1.5rem;
+			padding-right: 1.5rem;
+			padding-top: 6rem;
+			padding-bottom: 6rem;
+		}
+
+		.main {
+			display: flex;
+		}
+
+		.error-code {
+			font-size: 3rem;
+			line-height: 1;
+		}
+
+		.message-wrapper {
+			margin-left: 1.5rem;
+		}
+
+		.message-main {
+			border-style: solid;
+			border-top-width: 0;
+			border-right-width: 0;
+			border-bottom-width: 0;
+			border-left-width: 1px;
+			border-color: #e5e7eb;
+			padding-left: 1.5rem;
+		}
+	}
+
+	@media (min-width: 768) {
+		.error-container {
+			display: grid;
+			place-items: center;
+		}
+	}
+
+	@media (min-width: 1024px) {
+		.error-container {
+			padding-left: 2rem;
+			padding-right: 2rem;
+		}
+	}
+</style>

--- a/resources/internal/templates/themes/error.unstyled.svelte
+++ b/resources/internal/templates/themes/error.unstyled.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { page } from '$app/stores';
+</script>
+
+<svelte:head>
+	<title>{$page.status}: {$page.error.message}</title>
+</svelte:head>
+
+<h1>{$page.status}</h1>
+<p>{$page.error.message}</p>


### PR DESCRIPTION
add `+error.svelte` file over project creation instead to gather it from sthe starter template app
