### PR TITLE
fix: make generated page variable reactive

### DIFF
--- a/resources/internal/templates/resource/page.svelte.gotxt
+++ b/resources/internal/templates/resource/page.svelte.gotxt
@@ -1,9 +1,8 @@
 {{ $varName := .Name | ToVariableName | ReplaceIfNested }}
 <script lang="ts">
-    import { page } from '$app/stores';
 	import type { PageData } from './$types';
 	import type { Sveltin } from 'src/sveltin';
-	import type { IWebPageMetadata } from '@sveltinio/seo/types';
+	import { page } from '$app/stores';
 	import { website } from '$config/website.js';
 	import { Card } from '@sveltinio/widgets';
 	import { OpenGraphType, TwitterCardType } from '@sveltinio/seo/types';
@@ -11,10 +10,9 @@
 	import { ToTitle, getFavicon, getPageUrl } from '$lib/utils/strings.js';
 
 	export let data: PageData;
-	let resourceName = data.resourceName;
-	let items = data.items as Array<Sveltin.ContentEntry>;
+	$: ({ resourceName, items } = data);
 
-	const {{ $varName }}IndexPage: IWebPageMetadata = {
+	$: {{ $varName }}IndexPage = {
 		url: getPageUrl(resourceName, website),
 		title: website.name,
 		description: 'Here you can find the list of all available {{ .Name }}.',

--- a/resources/internal/templates/resource/slug.svelte.gotxt
+++ b/resources/internal/templates/resource/slug.svelte.gotxt
@@ -15,71 +15,67 @@
 	$: previous = before;
 	$: next = after;
 
-	let slugPageData = {} as IWebPageMetadata;
-	if (current) {
-		slugPageData = {
-			url: getSlugPageUrl(current, website),
-			title: current.metadata.title,
-			description: current.metadata.headline,
-			keywords: website.keywords ? website.keywords : '',
-			author: current.metadata.author,
-			image: getCoverImagePath(current, website),
-			opengraph: {
-				type: OpenGraphType.Article,
-				article: {
-					published_at: current.metadata.created_at,
-					modified_at: current.metadata.updated_at
-				}
-			},
-			twitter: {
-				type: TwitterCardType.Summary
+	$: slugPageData = {
+		url: getSlugPageUrl(current, website),
+		title: current.metadata.title,
+		description: current.metadata.headline,
+		keywords: website.keywords ? website.keywords : '',
+		author: current.metadata.author,
+		image: getCoverImagePath(current, website),
+		opengraph: {
+			type: OpenGraphType.Article,
+			article: {
+				published_at: current.metadata.created_at,
+				modified_at: current.metadata.updated_at
 			}
-		};
-	}
+		},
+		twitter: {
+			type: TwitterCardType.Summary
+		}
+	};
 </script>
 
-{#if current}
-	<PageMetaTags data={slugPageData} />
-	<JsonLdWebPage data={slugPageData} />
-	<JsonLdBreadcrumbs
-		baseURL={website.baseURL}
-		parent={current.resource}
-		currentTitle={slugPageData.title}
-	/>
+<PageMetaTags data={slugPageData} />
+<JsonLdWebPage data={slugPageData} />
+<JsonLdBreadcrumbs
+	baseURL={website.baseURL}
+	parent={current.resource}
+	currentTitle={slugPageData.title}
+/>
 
-	<article class="artifact-container">
-		<div class="content">
-			<h1>{current.metadata.title}</h1>
-			{#if current.metadata.created_at}
-				<h3>
-					<time datetime={new Date(current.metadata.created_at).toISOString()} />
-				</h3>
-			{/if}
-			{#if current.metadata.cover}
-				<div class="cover">
-					<img
-						src={`/resources/${current.resource}/${current.metadata.slug}/${current.metadata.cover}`}
-						title={`cover for ${current.metadata.title}`}
-						alt={`cover for ${current.metadata.title}`}
-					/>
-				</div>
-			{/if}
-			<div>
-				<TOC
-					resource={current.resource}
-					slug={current.metadata.slug}
-					headings={current.metadata.headings}
-					withChildren={true}
+<article class="artifact-container">
+	<div class="content">
+		<h1>{current.metadata.title}</h1>
+		{#if current.metadata.created_at}
+			<h3>
+				<time datetime={new Date(current.metadata.created_at).toISOString()} />
+			</h3>
+		{/if}
+		{#if current.metadata.cover}
+			<div class="cover">
+				<img
+					src={`/resources/${current.resource}/${current.metadata.slug}/${current.metadata.cover}`}
+					title={`cover for ${current.metadata.title}`}
+					alt={`cover for ${current.metadata.title}`}
 				/>
-
-				<div class="markdown-body">
-					<svelte:component this={mdsvexComponent} />
-				</div>
 			</div>
-			<PrevNextButtons {previous} {next} />
+		{/if}
+		<div>
+			<TOC
+				resource={current.resource}
+				slug={current.metadata.slug}
+				headings={current.metadata.headings}
+				withChildren={true}
+			/>
+
+			<div class="markdown-body">
+				<svelte:component this={mdsvexComponent} />
+			</div>
 		</div>
-	</article>
-{/if}
+		<PrevNextButtons {previous} {next} />
+	</div>
+</article>
+
 
 <style>
 	.cover {


### PR DESCRIPTION
The generated page variable is now reactive since it uses reactive data from Response.

This fixes the update when user navigates to other pages and cleanup the page code.
