### PR TITLE
chore: deps updated

### DIFF
--- a/resources/internal/templates/themes/blank/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/bootstrap/package.json.gotxt
@@ -14,10 +14,10 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
+		"@indaco/svelte-iconoir": "^2.6.0",
 		"@popperjs/core": "^2.11.6",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.480",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/blank/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/bulma/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/blank/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/scss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/blank/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/tailwindcss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/blank/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/vanillacss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/sveltin/bootstrap/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/bootstrap/package.json.gotxt
@@ -14,10 +14,10 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
+		"@indaco/svelte-iconoir": "^2.6.0",
 		"@popperjs/core": "^2.11.6",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.480",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/sveltin/bulma/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/bulma/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/sveltin/scss/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/scss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/sveltin/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/tailwindcss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",

--- a/resources/internal/templates/themes/sveltin/vanillacss/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/vanillacss/package.json.gotxt
@@ -14,9 +14,9 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@indaco/svelte-iconoir": "^2.5.1",
-		"@sveltejs/adapter-static": "1.0.0-next.42",
-		"@sveltejs/kit": "1.0.0-next.472",
+		"@indaco/svelte-iconoir": "^2.6.0",
+		"@sveltejs/adapter-static": "1.0.0-next.43",
+		"@sveltejs/kit": "1.0.0-next.481",
 		"@sveltinio/essentials": "^0.2.1",
 		"@sveltinio/media-content": "^0.3.2",
 		"@sveltinio/seo": "^0.1.7",


### PR DESCRIPTION
- @indaco/svelte-iconoir -> v2.6.0
- @sveltejs/adapter-static -> v1.0.0-next.43
- @sveltejs/kit -> v1.0.0-next.481
