### PR TITLE
fix: #153

### DIFF
--- a/resources/internal/templates/themes/blank/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/blank/tailwindcss/package.json.gotxt
@@ -26,7 +26,6 @@
 		"@sveltinio/services": "^0.3.4",
 		"@sveltinio/widgets": "^0.6.1",
 		"@tailwindcss/aspect-ratio": "^0.4.2",
-		"@tailwindcss/line-clamp": "^0.4.2",
 		"@tailwindcss/typography": "^0.5.9",
 		"@types/gtag.js": "^0.0.12",
 		"@types/lodash-es": "^4.17.6",
@@ -57,7 +56,7 @@
 		"svelte": "^3.55.1",
 		"svelte-check": "^3.0.3",
 		"svelte-preprocess": "^5.0.1",
-		"tailwindcss": "^3.2.7",
+		"tailwindcss": "^3.3.3",
 		"tslib": "^2.5.0",
 		"typescript": "^4.9.5",
 		"vite": "^4.1.4"

--- a/resources/internal/templates/themes/blank/tailwindcss/tailwind.config.cjs
+++ b/resources/internal/templates/themes/blank/tailwindcss/tailwind.config.cjs
@@ -7,7 +7,6 @@ const config = {
 	],
 	plugins: [
 		require('@tailwindcss/typography'),
-		require('@tailwindcss/line-clamp'),
 		require('@tailwindcss/aspect-ratio'),
 		plugin(function ({ addVariant, e, postcss }) {
 			addVariant('firefox', ({ container, separator }) => {

--- a/resources/internal/templates/themes/sveltin/tailwindcss/package.json.gotxt
+++ b/resources/internal/templates/themes/sveltin/tailwindcss/package.json.gotxt
@@ -26,7 +26,6 @@
 		"@sveltinio/services": "^0.3.4",
 		"@sveltinio/widgets": "^0.6.1",
 		"@tailwindcss/aspect-ratio": "^0.4.2",
-		"@tailwindcss/line-clamp": "^0.4.2",
 		"@tailwindcss/typography": "^0.5.9",
 		"@types/gtag.js": "^0.0.12",
 		"@types/lodash-es": "^4.17.6",
@@ -57,7 +56,7 @@
 		"svelte": "^3.55.1",
 		"svelte-check": "^3.0.3",
 		"svelte-preprocess": "^5.0.1",
-		"tailwindcss": "^3.2.7",
+		"tailwindcss": "^3.3.3",
 		"tslib": "^2.5.0",
 		"typescript": "^4.9.5",
 		"vite": "^4.1.4"

--- a/resources/internal/templates/themes/sveltin/tailwindcss/tailwind.config.cjs
+++ b/resources/internal/templates/themes/sveltin/tailwindcss/tailwind.config.cjs
@@ -53,7 +53,6 @@ const config = {
 	},
 	plugins: [
 		require('@tailwindcss/typography'),
-		require('@tailwindcss/line-clamp'),
 		require('@tailwindcss/aspect-ratio'),
 		plugin(function ({ addVariant, e, postcss }) {
 			addVariant('firefox', ({ container, separator }) => {


### PR DESCRIPTION
update tailwindcss to v3.3.3 and remove `lineclamp` plugin now included in the framework by default.